### PR TITLE
Make firewall config optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,7 @@ elk_kibana_password: kibana
 # "dashboard/Your-Dashboard-Name". You must replace whitespace in
 # dashboard names with hyphens, since Kibana expects it.
 elk_kibana_default_app: discover
+
+# Enable automatic configuration of IP whitelisting for "logclients".
+# Uses ufw. Disable if you're using a different role for firewall config.
+elk_configure_firewall: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
   tags: nginx
 
 - include: ufw.yml
+  when: elk_configure_firewall == true
   tags: ufw
 
 - include: snapshot.yml


### PR DESCRIPTION
On by default, but allows the role to defer firewall management to a
separate role, which is a likely situation in staging or prod. The sane
default is to whitelist IPs, since with minimum configuration the role
should be rather sanely safe.

For the same reason, we're not shipping a default cert with the role,
but rather forcing generation via an external dependency.
