### PR TITLE
Updates timestamp in Nagios log parsing

### DIFF
--- a/files/logstash-configs/24-nagios.conf
+++ b/files/logstash-configs/24-nagios.conf
@@ -6,5 +6,8 @@ filter {
     grok {
       match => { "message" => "%{NAGIOSLOGLINE}" }
     }
+    date {
+      match => ["nagios_epoch", "UNIX"]
+    }
   }
 }


### PR DESCRIPTION
Refer to the epoch timestamp from the actual log event, rather than
trusting the '@timestamp' field automatically created by Logstash. The
latter stamps the time of log ingestion, not the time of the event.