### PR TITLE
Fail2ban log parsing

### DIFF
--- a/files/logstash-configs/18-fail2ban.conf
+++ b/files/logstash-configs/18-fail2ban.conf
@@ -22,5 +22,14 @@ filter {
     mutate {
       remove_tag => ["_grokparsefailure"]
     }
+
+    if [fail2ban_clientip] {
+      geoip {
+        source => "fail2ban_clientip"
+        target => "geoip"
+        add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
+        add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
+      }
+    }
   }
 }

--- a/files/logstash-configs/18-fail2ban.conf
+++ b/files/logstash-configs/18-fail2ban.conf
@@ -1,0 +1,26 @@
+filter {
+  if [type] == "fail2ban" {
+    grok {
+      patterns_dir => ["/etc/logstash/patterns"]
+      match => [ "message", "%{FAIL2BAN_BAN}" ]
+      add_tag => [ "ban" ]
+      named_captures_only => true
+    }
+    grok {
+      patterns_dir => [ "/etc/logstash/patterns" ]
+      match => [ "message", "%{FAIL2BAN_UNBAN}" ]
+      add_tag => [ "unban" ]
+      named_captures_only => true
+    }
+    grok {
+      patterns_dir => [ "/etc/logstash/patterns" ]
+      match => [ "message", "%{FAIL2BAN_ALREADYBAN}" ]
+      add_tag => [ "already_ban" ]
+      named_captures_only => true
+    }
+
+    mutate {
+      remove_tag => ["_grokparsefailure"]
+    }
+  }
+}

--- a/files/logstash-configs/18-fail2ban.conf
+++ b/files/logstash-configs/18-fail2ban.conf
@@ -1,19 +1,19 @@
 filter {
   if [type] == "fail2ban" {
     grok {
-      patterns_dir => ["/etc/logstash/patterns"]
+      patterns_dir => ["/etc/logstash/patterns.d"]
       match => [ "message", "%{FAIL2BAN_BAN}" ]
       add_tag => [ "ban" ]
       named_captures_only => true
     }
     grok {
-      patterns_dir => [ "/etc/logstash/patterns" ]
+      patterns_dir => [ "/etc/logstash/patterns.d" ]
       match => [ "message", "%{FAIL2BAN_UNBAN}" ]
       add_tag => [ "unban" ]
       named_captures_only => true
     }
     grok {
-      patterns_dir => [ "/etc/logstash/patterns" ]
+      patterns_dir => [ "/etc/logstash/patterns.d" ]
       match => [ "message", "%{FAIL2BAN_ALREADYBAN}" ]
       add_tag => [ "already_ban" ]
       named_captures_only => true
@@ -30,6 +30,9 @@ filter {
         add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
         add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
       }
+    }
+    date {
+      match => ["fail2ban_timestamp", "ISO8601"]
     }
   }
 }

--- a/files/logstash-patterns/fail2ban
+++ b/files/logstash-patterns/fail2ban
@@ -1,0 +1,3 @@
+FAIL2BAN_BAN %{TIMESTAMP_ISO8601:timestamp} %{JAVACLASS:criteria}: %{LOGLEVEL:level} \[%{WORD:service}\] Ban %{IPV4:clientip}
+FAIL2BAN_UNBAN %{TIMESTAMP_ISO8601:timestamp} %{JAVACLASS:criteria}: %{LOGLEVEL:level} \[%{WORD:service}\] Unban %{IPV4:clientip}
+FAIL2BAN_ALREADYBAN %{TIMESTAMP_ISO8601:timestamp} %{JAVACLASS:criteria}: %{LOGLEVEL:level} \[%{WORD:service}\] %{IPV4:clientip} already banned

--- a/files/logstash-patterns/fail2ban
+++ b/files/logstash-patterns/fail2ban
@@ -1,3 +1,3 @@
-FAIL2BAN_BAN %{TIMESTAMP_ISO8601:timestamp} %{JAVACLASS:criteria}: %{LOGLEVEL:level} \[%{WORD:service}\] Ban %{IPV4:clientip}
-FAIL2BAN_UNBAN %{TIMESTAMP_ISO8601:timestamp} %{JAVACLASS:criteria}: %{LOGLEVEL:level} \[%{WORD:service}\] Unban %{IPV4:clientip}
-FAIL2BAN_ALREADYBAN %{TIMESTAMP_ISO8601:timestamp} %{JAVACLASS:criteria}: %{LOGLEVEL:level} \[%{WORD:service}\] %{IPV4:clientip} already banned
+FAIL2BAN_BAN %{TIMESTAMP_ISO8601:fail2ban_timestamp} %{GREEDYDATA:fail2ban_criteria}: %{LOGLEVEL:fail2ban_loglevel} \[%{WORD:fail2ban_service}\] Ban %{IPV4:fail2ban_clientip}
+FAIL2BAN_UNBAN %{TIMESTAMP_ISO8601:fail2ban_timestamp} %{GREEDYDATA:fail2ban_criteria}: %{LOGLEVEL:fail2ban_loglevel} \[%{WORD:fail2ban_service}\] Unban %{IPV4:fail2ban_clientip}
+FAIL2BAN_ALREADYBAN %{TIMESTAMP_ISO8601:fail2ban_timestamp} %{GREEDYDATA:fail2ban_criteria}: %{LOGLEVEL:fail2ban_loglevel} \[%{WORD:fail2ban_service}\] %{IPV4:fail2ban_clientip} already banned


### PR DESCRIPTION
This log is very simple to parse. The filter includes tags for ban and unban actions, plus geolocation.