### PR TITLE
Remove Slack alerts for failed SSH logins

### DIFF
--- a/files/logstash-configs/21-ssh-logins.conf
+++ b/files/logstash-configs/21-ssh-logins.conf
@@ -41,13 +41,6 @@ filter {
         add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
       }
     }
-    if "ssh_failure" in [tags] {
-      mutate {
-        add_tag => "slack_alert"
-        add_field => { "original_message" => "%{message}" }
-        replace => { "message" => "Failed login for user %{username} from IP %{src_ip}" }
-      }
-    }
     if "ssh_success" in [tags] {
       mutate {
         add_tag => "slack_alert"


### PR DESCRIPTION
Feedback from @garrettr and myself is that failed SSH login alerts amount to non-useful noise. 