### PR TITLE
Defaults to Debian 8 in test suite

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -1,6 +1,7 @@
 ---
 ansible:
   verbose: vv
+  diff: yes
 
 vagrant:
   platforms:

--- a/molecule.yml
+++ b/molecule.yml
@@ -4,11 +4,11 @@ ansible:
 
 vagrant:
   platforms:
-    - name: wily64
-      box: ubuntu/wily64
-
     - name: jessie64
       box: debian/jessie64
+
+    - name: wily64
+      box: ubuntu/wily64
 
   providers:
     - name: virtualbox


### PR DESCRIPTION
By default tests should run under Debian 8. Ubuntu Wily is still available, just use the `--platform` option on the test step for molecule. Closes #29.