### PR TITLE
Sets pam limits for elasticsearch user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,29 @@ elk_elasticsearch_snapshot_initialization:
 # throws an invalid_snapshot_name error with the iso8601 format.
 elk_elasticsearch_snapshot_name: "snapshot-{{ ansible_date_time.epoch }}"
 
+# Limits to set in /etc/security/limits.conf. Make sure to copy the entire
+# list if overriding any of the individual elements.
+elk_elasticsearch_pam_limits:
+    - domain: elasticsearch
+      limit_item: memlock
+      limit_type: hard
+      value: unlimited
+
+    - domain: elasticsearch
+      limit_item: memlock
+      limit_type: soft
+      value: unlimited
+
+    - domain: elasticsearch
+      limit_item: nofile
+      limit_type: soft
+      value: 65535
+
+    - domain: elasticsearch
+      limit_item: nofile
+      limit_type: hard
+      value: 65535
+
 # Riemann plugin for alerting, de-dot filter for ElasticSearch v2 compatibility.
 # See: https://www.elastic.co/blog/introducing-the-de_dot-filter
 elk_logstash_plugins:

--- a/spec/elasticsearch_spec.rb
+++ b/spec/elasticsearch_spec.rb
@@ -42,6 +42,25 @@ describe file('/etc/default/elasticsearch') do
   its('content') { should match(/^ES_HEAP_SIZE=#{desired_heap_size}m/) }
 end
 
+describe file('/etc/security/limits.conf') do
+  it { should be_file }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should eq '644' }
+  its('content') do
+    should match(/^elasticsearch\s+soft\s+memlock\s+unlimited$/)
+  end
+  its('content') do
+    should match(/^elasticsearch\s+hard\s+memlock\s+unlimited$/)
+  end
+  its('content') do
+    should match(/^elasticsearch\s+soft\s+nofile\s+65535$/)
+  end
+  its('content') do
+    should match(/^elasticsearch\s+hard\s+nofile\s+65535$/)
+  end
+end
+
 describe service('elasticsearch') do
   it { should be_running }
   it { should be_enabled }

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -72,6 +72,15 @@
     line: "ES_HEAP_SIZE={{ elasticsearch_heap_size }}m"
     state: present
 
+- name: Set PAM limits for elasticsearch user.
+  pam_limits:
+    domain: "{{ item.domain }}"
+    limit_item: "{{ item.limit_item }}"
+    limit_type: "{{ item.limit_type }}"
+    value: "{{ item.value }}"
+    backup: yes
+  with_items: "{{ elk_elasticsearch_pam_limits }}"
+
 - name: Start elasticsearch service.
   service:
     name: elasticsearch


### PR DESCRIPTION
The elasticsearch service logs warning messages if generous ulimits for memlock are not configured (see #10). This PR implements unlimited soft and hard limits for `memlock` specifically for the `elasticsearch` user.

There are also limits configured to raise the number of open files permissible, which is essential for a system running both logstash and elasticsearch. Right now it's setting a sane limit for `nofile` of 65535. This is a judgment call, trying to strike a balance between the system default (1024) versus something much higher, such as 200000 or unlimited. If admins want a higher limit, they can simply override the middle-of-the-road value via default vars.

Closes #10.