### PR TITLE
Documents development workflow for writing logstash filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ See the [Molecule] docs for more info.
 * [Grok Constructor](http://grokconstructor.appspot.com/)
 * [How to develop Logstash configuration files](http://blog.comperiosearch.com/blog/2015/04/10/how-to-develop-logstash-configuration-files/)
 
+See the [examples/writing-filters](examples/writing-filters) directory in this repo
+for a preconfigured development environment. Copy that directory to a server with
+logstash installed, or use a Vagrant testing VM.
+
 ### Maintenance
 
 * [Elasticsearch Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/command-line.html)

--- a/examples/writing-filters/01-input.conf
+++ b/examples/writing-filters/01-input.conf
@@ -1,0 +1,14 @@
+input {
+  generator {
+    lines => [
+      ""
+    ]
+    count => 1
+    type => "apache"
+  }
+}
+
+# After updating the loglines above, run:
+#   /opt/logstash/bin/logstash -f .
+# from within this directory. Logstash will run, parse the loglines,
+# then exit. Be patient, the process can take nearly a minute sometimes!

--- a/examples/writing-filters/01-input.conf
+++ b/examples/writing-filters/01-input.conf
@@ -1,10 +1,19 @@
 input {
   generator {
+
+    # Add your example loglines here. It's a list, so you can add as many as you like.
+    # It's a good idea to include several different formats to ensure your filter
+    # matches multiple line patterns without failing.
+
     lines => [
-      ""
+     '127.0.0.1 - - [11/Dec/2013:00:01:45 -0800] "GET /xampp/status.php HTTP/1.1" 200 3891 "http://cadenza/xampp/navi.php" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0"'
     ]
+
     count => 1
-    type => "apache"
+
+    # The tag must match the tag your filter checks.
+    type => "foo"
+
   }
 }
 

--- a/examples/writing-filters/22-foo.conf
+++ b/examples/writing-filters/22-foo.conf
@@ -1,0 +1,14 @@
+filter {
+  # The tag must match the tag in the input config file.
+  if [type] == "foo" {
+    grok {
+      # Write your custom matching rules here. The core pattern
+      # for apache is just an example.
+      match => { "message" => "%{COMBINEDAPACHELOG}" }
+    }
+    date {
+      match => [ "timestamp" , "dd/MMM/yyyy:HH:mm:ss Z" ]
+    }
+  }
+}
+

--- a/examples/writing-filters/99-output.conf
+++ b/examples/writing-filters/99-output.conf
@@ -1,0 +1,5 @@
+output {
+    stdout {
+        codec => "rubydebug"
+    }
+}


### PR DESCRIPTION
Setting up a decent dev environment for logstash filters is a pain, but these example files make it much easier. This is precisely what I use when writing new filters, and having templates in the repo makes it convenient to fall back to a clean slate between filter versions.

There are already a few resources linked to in the README, but these example files are much simpler to get started with.

Closes #27.