### PR TITLE
Fix parsing of redmine_timestamp offset

### DIFF
--- a/files/logstash-configs/22-redmine.conf
+++ b/files/logstash-configs/22-redmine.conf
@@ -135,7 +135,7 @@ filter {
     }
     if [redmine_timestamp] {
       date {
-        match => ["redmine_timestamp", "yyyy-MM-dd HH:mm:ss z"]
+        match => ["redmine_timestamp", "yyyy-MM-dd HH:mm:ss Z"]
       }
     }
   }


### PR DESCRIPTION
Error in logstash.log:
```{:timestamp=>"2016-04-21T16:59:48.782000-0700", :message=>"Failed parsing date from field", :field=>"redmine_timestamp", :value=>"2016-04-21 16:59:39 -0700", :exception=>"Invalid format: \"2016-04-21 16:59:39 -0700\" is malformed at \"-0700\"", :config_parsers=>"yyyy-MM-dd HH:mm:ss z", :config_locale=>"default=en_US", :level=>:warn}```
