### PR TITLE
Adds missing patterns.d directory include for ufw filters

### DIFF
--- a/files/logstash-configs/23-ufw.conf
+++ b/files/logstash-configs/23-ufw.conf
@@ -3,6 +3,7 @@ filter {
     grok {
       # Matches:
       # Feb 22 19:06:53 fpf-base-image kernel: [ 5431.910027] [UFW BLOCK] IN=eth0 OUT= MAC=04:01:ad:62:2d:01:3c:8a:b0:0d:6f:f0:08:00 SRC=50.233.105.123 DST=159.203.252.45 LEN=60 TOS=0x00 PREC=0x00 TTL=54 ID=57172 DF PROTO=TCP SPT=40169 DPT=3389 WINDOW=29200 RES=0x00 SYN URGP=0
+      patterns_dir   => "/etc/logstash/patterns.d"
       match => { "message" => "%{UFW_LOG}" }
     }
     if [ufw_src_ip] {


### PR DESCRIPTION
Changes were introduced in 0bb1e2ffdda956594d05e4ffe224f238210e43e8,
adding custom patterns for UFW. In order to use custom patterns, the
directory housing the them must be explicitly declared in the grok
stanza referencing them. Fixed.