### PR TITLE
Daily host metrics posted to Slack

### DIFF
--- a/files/logstash-configs/41-daily-metrics.conf
+++ b/files/logstash-configs/41-daily-metrics.conf
@@ -1,0 +1,21 @@
+filter {
+  if [type] == "system" {
+    ruby {
+      code => "
+        event['daily_stat'] = true if Time.now.hour == 12 && Time.now.min == 0
+        if event['daily_stat']
+          event['stat_mem'] = event['mem']['actual_used_p'] * 100.to_f
+          event['stat_mem'] = event['stat_mem'].to_i.to_s
+          event['stat_load'] = event['load']['load15'].to_f.to_s
+        end
+      "
+    }
+    if [daily_stat] {
+      mutate {
+        add_tag => "slack_alert"
+        add_tag => "daily_stats"
+        replace => { "message" => "Memory usage: %{[stat_mem]}% | Average load: %{[stat_load]}" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Assumes the Topbeat period is 60, so there will be an update within a minute after 12 noon.

Uses Ruby filter to handle typing and timing.

Replacing the `message` field makes the original Topbeat message hard to debug, so it's advisable to make a new field called `alert_message` and tell Riemann to use that. Requires updating the Riemann config.