### PR TITLE
Adds custom filepath for OpenSSL certificate and key

### DIFF
--- a/files/logstash-configs/01-lumberjack-input.conf
+++ b/files/logstash-configs/01-lumberjack-input.conf
@@ -5,8 +5,8 @@ input {
   beats {
     port => 5000
     ssl => true
-    ssl_certificate => "/etc/pki/tls/certs/logstash-client.crt"
-    ssl_key => "/etc/pki/tls/private/logstash-client.key"
+    ssl_certificate => "/etc/logstash/logstash-client.crt"
+    ssl_key => "/etc/logstash/logstash-client.key"
   }
 }
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,3 +20,16 @@ galaxy_info:
 dependencies:
   - role: freedomofpress.generate-ssl-cert
     ssl_certificate_basename: logstash-client
+    ssl_certificate_create_users: ['logstash']
+    ssl_certificate_permissions_map:
+      basename: "{{ ssl_certificate_basename }}"
+      cert:
+        path: "/etc/logstash/{{ ssl_certificate_basename }}.crt"
+        mode: "0644"
+        owner: root
+        group: logstash
+      key:
+        path: "/etc/logstash/{{ ssl_certificate_basename }}.key"
+        mode: "0640"
+        owner: root
+        group: logstash

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -33,3 +33,5 @@ dependencies:
         mode: "0640"
         owner: root
         group: logstash
+    ssl_certificate_dynamic_handlers:
+      - restart logstash


### PR DESCRIPTION
The upstream freedomofpress.generate-ssl-cert role now supports
fine-grained permissions management. Rather than place the certificate
and keyfile for the Logstash service in the system-wide CA directory,
place them in the Logstash config directory with permissions on the key
so that it is readable by the "logstash" user.

Requires a hard-coded change to the Logstash input config, since the
config files are not yet templatized, meaning no vars can be interpolated.