### PR TITLE
Catch and alert when Redmine_OpenPGP fails to decrypt message

### DIFF
--- a/files/logstash-configs/22-redmine.conf
+++ b/files/logstash-configs/22-redmine.conf
@@ -73,6 +73,14 @@ filter {
         match => { message => "%{REDMINE_ISSUE_CREATED}" }
         add_tag => "issue_created"
       }
+      grok {
+        # matches:
+        # MailHandler: an unexpected error occurred when receiving email: Decryption failed
+        patterns_dir => [ "/etc/logstash/patterns.d" ]
+        match => { message => "%{REDMINE_FAILED_DECRYPT}" }
+        add_tag => "failed_decrypt"
+        add_tag => "slack_alert"
+      }
     }
 
     else {

--- a/files/logstash-patterns/redmine
+++ b/files/logstash-patterns/redmine
@@ -4,6 +4,7 @@ REDMINE_FAILED_LOGIN Failed login for '%{USERNAME:username}' from %{IP:src_ip} a
 REDMINE_SUCCESSFUL_LOGIN Successful authentication for '%{USERNAME:username}' from %{IP:src_ip} at %{TIMESTAMP_ISO8601:redmine_auth_timestamp}
 REDMINE_RECEIVED_MAIL MailHandler: received email from %{EMAILADDRESS} with Message-ID (?<message_id>[^\s]+): encrypted=(?<encrypted>(true|false)), valid=(?<valid>(true|false)), ignored=(?<ignored>(true|false))
 REDMINE_IGNORED_MAIL MailHandler: ignoring email with %{DATA:header} header
+REDMINE_FAILED_DECRYPT MailHandler: an unexpected error occurred when receiving email: Decryption failed
 REDMINE_NO_PUBKEY No public key found for (?<fullname>[^<]+) <%{EMAILADDRESS}> \(%{BASE10NUM:key_id}\)
 REDMINE_TIMESTAMP %{YEAR:year}-%{MONTHNUM:month}-%{MONTHDAY:day} %{TIME:time} %{ISO8601_TIMEZONE}
 REDMINE_REQUEST_COMPLETED Completed %{BASE10NUM:http_status_code} %{WORD:http_status_human_readable} in %{BASE10NUM:request_time}%{DATA:request_time_units} \((Views: %{BASE10NUM:views_time}%{DATA:views_time_units} \| )?ActiveRecord: %{BASE10NUM:activerecord_time}%{DATA:activerecord_time_units}\)


### PR DESCRIPTION
When the wrong key is used to send email to support@freedom.press, or PGP
ciphertext encrypted to the wrong key is embedded in a contact form submission,
the ticket will be discarded. We should be tagging and alerting on this so that
we can attempt to recover the information.