### PR TITLE
Refines alerting strategy for SSH logins

### DIFF
--- a/files/logstash-configs/21-ssh-logins.conf
+++ b/files/logstash-configs/21-ssh-logins.conf
@@ -5,51 +5,52 @@ filter {
     grok {
       match => {"message" => "%{SYSLOGTIMESTAMP:timestamp} %{HOSTNAME:host_target} sshd\[%{BASE10NUM}\]" }
       add_tag => "ssh"
+      break_on_match => false
     }
-    if "ssh" in [tags] {
-      grok {
-        match => {"message" => "(Failed password for )?[iI]nvalid user %{USERNAME:username}( from %{IP:src_ip})?( port %{BASE10NUM:port})?" }
-        add_tag => "ssh_failure"
-        add_tag => "ssh_brute_force_attack"
-      }
-      grok {
-        match => { "message" => "sudo: pam_unix\(sudo:auth\): authentication failure; logname=%{USERNAME:logname} uid=%{BASE10NUM:uid} euid=%{BASE10NUM:euid} tty=%{TTY:tty} ruser=%{USERNAME:ruser} rhost=(?:%{HOSTNAME:remote_host}|\s*) user=%{USERNAME:user}" }
-        add_tag => "ssh_failure"
-        add_tag => "sudo_auth_failure"
-      }
-      grok {
-        match => { "message" => "sshd\[%{BASE10NUM}\]: Failed password for %{USERNAME:username} from %{IP:src_ip}( port %{BASE10NUM:port})?" }
-        add_tag => "ssh_failure"
-        add_tag => "ssh_failed_login"
-      }
-      grok {
-        match => { "message" => "sshd\[%{BASE10NUM}\]: Accepted (?<auth_method>(password|publickey)) for %{USERNAME:username} from %{IP:src_ip} port %{BASE10NUM:port} ssh2" }
-        add_tag => "ssh_success"
-        add_tag => "ssh_successful_login"
-      }
-      grok {
-        match => { "message" => "pam_unix\(sshd:session\): session opened for user %{USERNAME:username} by \(uid=%{BASE10NUM:by_uid}\)" }
-        add_tag => "ssh_success"
-        add_tag => "ssh_successful_login"
-      }
+    grok {
+      match => {"message" => "(Failed password for )?[iI]nvalid user %{USERNAME:username}( from %{IP:src_ip})?( port %{BASE10NUM:port})?" }
+      add_tag => "ssh_failure"
+      break_on_match => false
     }
-    if [src_ip] {
-      geoip {
-        source => "src_ip"
-        target => "geoip"
-        add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
-        add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
-      }
+    grok {
+      match => { "message" => "sudo: pam_unix\(sudo:auth\): authentication failure; logname=%{USERNAME:logname} uid=%{BASE10NUM:uid} euid=%{BASE10NUM:euid} tty=%{TTY:tty} ruser=%{USERNAME:ruser} rhost=(?:%{HOSTNAME:remote_host}|\s*) user=%{USERNAME:user}" }
+      add_tag => "ssh_failure"
+      break_on_match => false
     }
-    if "ssh_success" in [tags] {
-      mutate {
-        add_tag => "slack_alert"
-        add_field => { "original_message" => "%{message}" }
-        replace => { "message" => "Interactive SSH login for user %{username} from IP %{src_ip}" }
-      }
+    grok {
+      match => { "message" => "sshd\[%{BASE10NUM}\]: Failed password for %{USERNAME:username} from %{IP:src_ip}( port %{BASE10NUM:port})?" }
+      add_tag => "ssh_failure"
+      break_on_match => false
     }
-    date {
-      match => ["timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss"]
+    grok {
+      match => { "message" => "sshd\[%{BASE10NUM}\]: Accepted (?<auth_method>(password|publickey)) for %{USERNAME:username} from %{IP:src_ip} port %{BASE10NUM:port} ssh2" }
+      add_tag => "ssh_success"
+      break_on_match => false
     }
+    grok {
+      match => { "message" => "pam_unix\(sshd:session\): session opened for user %{USERNAME:username} by \(uid=%{BASE10NUM:by_uid}\)" }
+      add_tag => "ssh_success"
+      break_on_match => false
+    }
+  }
+  if [src_ip] {
+    geoip {
+      source => "src_ip"
+      target => "geoip"
+      add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
+      add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
+    }
+  }
+  if "ssh_success" in [tags] {
+    grok {
+      match => { "source" => "/var/log/auth.log" }
+      add_tag => "slack_alert"
+      add_field => { "original_message" => "%{message}" }
+      add_field => { "alert_message" => "Interactive SSH login for user %{username} from IP %{src_ip}" }
+      break_on_match => false
+    }
+  }
+  date {
+    match => ["timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss"]
   }
 }

--- a/files/logstash-configs/21-ssh-logins.conf
+++ b/files/logstash-configs/21-ssh-logins.conf
@@ -50,7 +50,9 @@ filter {
       break_on_match => false
     }
   }
-  date {
-    match => ["timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss"]
+  if "ssh" in [tags] {
+    date {
+      match => ["timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss"]
+    }
   }
 }


### PR DESCRIPTION
Most notably leverages `break_on_match => false` for the SSH logins, to ensure that all possible matches are tried. Otherwise, the filter will bail out early and leave the `_grokparsefailure` tag assigned. Additionally filtering the syslog events to ensure that the date-parsing logic (#33) for SSH events only applies to events already tagged as "ssh".