### PR TITLE
Parse connection attempts to hidden services on wrong ports

### DIFF
--- a/files/logstash-configs/25-tor.conf
+++ b/files/logstash-configs/25-tor.conf
@@ -1,5 +1,14 @@
 filter {
   if [type] == "tor" {
+
+    # May 28 18:24:19.000 [info] rend_service_set_connection_addr_port(): No virtual port mapping exists for port 22 on service secrdrop5wyphb5x
+    grok {
+      patterns_dir => [ "/etc/logstash/patterns.d" ]
+      match => { "message" => "%{TOR_HIDSERV_ATTEMPT}" }
+      add_tag => "tor_hidserv_attempt"
+      remove_tag => "_grokparsefailure"
+    }
+
     grok {
       patterns_dir => [ "/etc/logstash/patterns.d" ]
       match => { "message" => "%{TOR_LOG}" }

--- a/files/logstash-patterns/tor
+++ b/files/logstash-patterns/tor
@@ -5,3 +5,4 @@ TOR_LOG %{TOR_LOG_PREFIX} %{GREEDYDATA:message}
 TOR_INFO_LOG %{TOR_LOG_PREFIX} %{WORD:action}(_*\(\))?: %{GREEDYDATA:message}
 TOR_NOTICE_TYPE [\w\s]+
 TOR_NOTICE_LOG %{TOR_LOG_PREFIX} %{TOR_NOTICE_TYPE:notice_type}: %{GREEDYDATA:message}
+TOR_HIDSERV_ATTEMPT %{TOR_LOG_PREFIX} rend_service_set_connection_addr_port\(\): No virtual port mapping exists for port %{INT:tor_hidserv_port} on service %{WORD:tor_hidserv_addr}


### PR DESCRIPTION
Per OSSEC alerts reported by SecureDrop admins, general crawling of the Tor
network, including with OnionScan, and logs aggregated by FPF, there are
frequent connection attempts to hidden services on ports other-than-specified.
These result in a warning in the Tor log:

`[warn] connection_edge_process_relay_cell (at origin) failed.`

This commit adds parsing for an associated info-level logline so we can analyze
these trends and the port numbers that are being tried in ELK.