### PR TITLE
Install Kibana from apt repositories instead of tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ for alerting functionality.
 
 ```yaml
 elk_nginx_user: "www-data"
-elk_kibana_version: "4.4.1"
 
 # Riemann plugin for alerting, de-dot filter for ElasticSearch v2 compatibility.
 # See: https://www.elastic.co/blog/introducing-the-de_dot-filter

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for alerting functionality.
 ## Role variables
 
 ```yaml
-elk_nginx_user: "www-data"
+elk_nginx_user: "kibana"
 
 # Riemann plugin for alerting, de-dot filter for ElasticSearch v2 compatibility.
 # See: https://www.elastic.co/blog/introducing-the-de_dot-filter

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for alerting functionality.
 ## Role variables
 
 ```yaml
-elk_nginx_user: "kibana"
+elk_kibana_user: "kibana"
 
 # Riemann plugin for alerting, de-dot filter for ElasticSearch v2 compatibility.
 # See: https://www.elastic.co/blog/introducing-the-de_dot-filter

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for elk
 
-elk_nginx_user: "kibana"
+elk_kibana_user: "kibana"
 elk_kibana_logfile: "/var/log/kibana.log"
 
 # Provide ability to disable the snapshot functionality. It's not well

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,6 @@
 # defaults file for elk
 
 elk_nginx_user: "www-data"
-elk_kibana_version: "4.4.1"
 elk_kibana_logfile: "/var/log/kibana.log"
 
 # Provide ability to disable the snapshot functionality. It's not well

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for elk
 
-elk_nginx_user: "www-data"
+elk_nginx_user: "kibana"
 elk_kibana_logfile: "/var/log/kibana.log"
 
 # Provide ability to disable the snapshot functionality. It's not well

--- a/spec/elasticsearch_spec.rb
+++ b/spec/elasticsearch_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe file('/etc/apt/sources.list.d/'\
               'packages_elastic_co_elasticsearch_2_x_debian.list') do
   it { should be_file }
-  its('mode') { should eq '644' }
+  its('mode') { should eq '420' }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
   repo_url = 'http://packages.elastic.co/elasticsearch/2.x/debian'

--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -3,13 +3,31 @@ require 'spec_helper'
 
 kibana_version = '4.5'
 
+describe file('/etc/apt/sources.list.d/'\
+              'packages_elastic_co_kibana_4_5_debian.list') do
+  it { should be_file }
+  its('mode') { should eq '644' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  repo_url = 'http://packages.elastic.co/kibana/4.5/debian'
+  its('content') { should include "deb #{repo_url}" }
+end
+
 describe package('kibana') do
   it { should be_installed }
+  its('version') { should >= kibana_version }
 end
 
 describe file('/opt/kibana') do
   it { should exist }
   it { should be_directory }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should eq '755' }
+
+  # Intentionally redundant test for backwards compatibility. Prior versions
+  # of the role set /opt/kibana to a symlink for tarball extraction.
+  it { should_not be_symlink }
 end
 
 describe file('/etc/systemd/system/kibana.service') do
@@ -21,7 +39,7 @@ describe file('/etc/systemd/system/kibana.service') do
 
   desired_service_config_lines = [
     'Environment=NODE_OPTIONS="--max-old-space-size=200"',
-    'User=www-data',
+    'User=kibana',
     'Environment=CONFIG_PATH=/opt/kibana/config/kibana.yml',
     'Environment=NODE_ENV=production'
   ]

--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -1,24 +1,9 @@
 # encoding: utf-8
 require 'spec_helper'
 
-kibana_version = '4.4.1'
-
-describe file("/opt/kibana-#{kibana_version}-linux-x64.tar.gz") do
-  it { should exist }
-  it { should be_file }
-end
-
-describe file("/opt/kibana-#{kibana_version}-linux-x64") do
-  it { should exist }
-  it { should be_directory }
-  its('owner') { should eq 'www-data' }
-  its('group') { should eq 'www-data' }
-end
-
 describe file('/opt/kibana') do
   it { should exist }
-  it { should be_symlink }
-  it { should be_linked_to "/opt/kibana-#{kibana_version}-linux-x64" }
+  it { should be_directory }
 end
 
 describe file('/etc/systemd/system/kibana.service') do

--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -1,6 +1,12 @@
 # encoding: utf-8
 require 'spec_helper'
 
+kibana_version = '4.5'
+
+describe package('kibana') do
+  it { should be_installed }
+end
+
 describe file('/opt/kibana') do
   it { should exist }
   it { should be_directory }

--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -6,7 +6,7 @@ kibana_version = '4.5'
 describe file('/etc/apt/sources.list.d/'\
               'packages_elastic_co_kibana_4_5_debian.list') do
   it { should be_file }
-  its('mode') { should eq '644' }
+  its('mode') { should eq '420' }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
   repo_url = 'http://packages.elastic.co/kibana/4.5/debian'

--- a/spec/logstash_spec.rb
+++ b/spec/logstash_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe file('/etc/apt/sources.list.d/'\
               'packages_elastic_co_logstash_2_2_debian.list') do
   it { should be_file }
-  its('mode') { should eq '644' }
+  its('mode') { should eq '420' }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
   repo_url = 'http://packages.elastic.co/logstash/2.2/debian'

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -1,9 +1,4 @@
 ---
-- name: Add ElasticSearch repo apt key.
-  apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
-    state: present
-
 - name: Add ElasticSearch apt repo.
   apt_repository:
     repo: "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main"

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -1,5 +1,0 @@
----
-- name: Install Java.
-  apt:
-    name: openjdk-7-jre-headless
-    state: present

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -6,6 +6,20 @@
   notify:
     - reload systemd
 
+  # Previous versions of the role used a symlink to support tarball extraction.
+  # Let's provide a sane upgrade path and handle the edge case where it's still
+  # a symlink by converting it to a directory.
+- name: Check Kibana directory.
+  stat:
+    path: /opt/kibana
+  register: kibana_directory_check
+
+- name: Remove Kibana symlink.
+  file:
+    path: /opt/kibana
+    state: absent
+  when: kibana_directory_check.stat.islnk
+
 - name: Install Kibana.
   apt:
     name: kibana

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -1,9 +1,4 @@
 ---
-- name: Add Kibana repo apt key.
-  apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
-    state: present
-
 - name: Add Kibana apt repo.
   apt_repository:
     repo: "deb http://packages.elastic.co/kibana/4.5/debian stable main"

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -28,10 +28,9 @@
     - reload systemd
     - restart kibana
 
-  # It's important to configure the init file first, since it notifies daemon-reload.
-  # This task must come before any task in the same play that will notify `restart kibana`,
-  # since Ansible queues handlers in the order they were notified. We want to ensure that if
-  # kibana is being restarted AND the service file changed, daemon-reload runs first.
+  # Overriding the default systemd service file that ships with the kibana
+  # apt package. The service file below was written when the role used
+  # a tarball extraction to deploy the kibana files.
 - name: Create Kibana systemd service file.
   template:
     src: kibana.service.j2

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -48,7 +48,7 @@
   copy:
     dest: "{{ elk_kibana_logfile }}"
     owner: root
-    group: "{{ elk_nginx_user }}"
+    group: "{{ elk_kibana_user }}"
     mode: "0660"
     force: no
     content: ""
@@ -63,7 +63,7 @@
   file:
     path: "{{ elk_kibana_logfile }}"
     owner: root
-    group: "{{ elk_nginx_user }}"
+    group: "{{ elk_kibana_user }}"
     mode: "0660"
   when: elk_kibana_logfile.startswith('/')
   notify: restart kibana

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -1,15 +1,23 @@
 ---
-- name: Download Kibana tarball.
-  get_url:
-    url: https://download.elastic.co/kibana/kibana/kibana-{{ elk_kibana_version }}-linux-x64.tar.gz
-    dest: /opt/kibana-{{ elk_kibana_version }}-linux-x64.tar.gz
-    # Don't download file every time, only if it doesn't exist.
-    force: no
+- name: Add Kibana repo apt key.
+  apt_key:
+    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    state: present
 
-- name: Check for existing Kibana installation.
-  stat:
-    path: /opt/kibana-{{ elk_kibana_version }}-linux-x64
-  register: kibana_directory_check
+- name: Add Kibana apt repo.
+  apt_repository:
+    repo: "deb http://packages.elastic.co/kibana/4.5/debian stable main"
+    state: present
+  notify:
+    - reload systemd
+
+- name: Install Kibana.
+  apt:
+    name: kibana
+    state: latest
+  notify:
+    - reload systemd
+    - restart kibana
 
   # It's important to configure the init file first, since it notifies daemon-reload.
   # This task must come before any task in the same play that will notify `restart kibana`,
@@ -25,23 +33,6 @@
   notify:
     - reload systemd
     - restart kibana
-
-- name: Extract Kibana tarball.
-  unarchive:
-    copy: no
-    src: /opt/kibana-{{ elk_kibana_version }}-linux-x64.tar.gz
-    dest: /opt/
-    owner: "{{ elk_nginx_user }}"
-    group: "{{ elk_nginx_user }}"
-  when: kibana_directory_check.stat.exists == false
-
-- name: Symlink Kibana directory.
-  file:
-    state: link
-    dest: /opt/kibana
-    src: /opt/kibana-{{ elk_kibana_version }}-linux-x64
-    owner: "{{ elk_nginx_user }}"
-    group: "{{ elk_nginx_user }}"
 
   # Two-pass approach to creating logfile idempotently. Create the empty logfile
   # if none exists (force: no), but to ensure permissions we need a second task.

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -1,9 +1,4 @@
 ---
-- name: Add Logstash repo apt key.
-  apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
-    state: present
-
 - name: Add Logstash apt repo.
   apt_repository:
     repo: "deb http://packages.elastic.co/logstash/2.2/debian stable main"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,9 @@
 - include: java.yml
   tags: java
 
+- include: packages.yml
+  tags: apt
+
 - include: elasticsearch.yml
   tags: elasticsearch
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,7 @@
 ---
 # tasks file for elk
-- include: java.yml
-  tags: java
-
 - include: packages.yml
-  tags: apt
+  tags: packages
 
 - include: elasticsearch.yml
   tags: elasticsearch

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -31,7 +31,8 @@
     password: "{{ elk_kibana_password }}"
     path: /etc/nginx/conf.d/kibana.htpasswd
     owner: root
-    group: "{{ elk_nginx_user }}"
+    # Assuming Debian 'www-data' web user for nginx.
+    group: www-data
     mode: "0640"
   notify: restart nginx
 

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,4 +1,12 @@
 ---
+- name: Install Java.
+  apt:
+    name: openjdk-7-jre-headless
+    state: present
+
+# This GPG key is used for checking signatures on packages for all three
+# components of the ELK stack (elasticsearch, logstash, and kibana).
+# Therefore let's add it once and be done with it.
 - name: Add Elastic repositories apt key.
   apt_key:
     url: https://packages.elastic.co/GPG-KEY-elasticsearch

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,0 +1,5 @@
+---
+- name: Add Elastic repositories apt key.
+  apt_key:
+    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    state: present

--- a/templates/kibana.service.j2
+++ b/templates/kibana.service.j2
@@ -3,7 +3,7 @@ Description=Kibana 4
 
 [Service]
 Type=simple
-User={{ elk_nginx_user }}
+User={{ elk_kibana_user }}
 Environment=CONFIG_PATH=/opt/kibana/config/kibana.yml
 Environment=NODE_ENV=production
 # Workaround to prevent OOM errors with kibana/node. Should be fixed in v4.4.


### PR DESCRIPTION
Updates the role to use Elastic's package repositories for installing Kibana instead of downloading the tarball, per issue #39.
Removes `elk_kibana_version`. The new version is 4.5 instead of 4.4.1.
Updates the spec tests.