### PR TITLE
Allows elasticsearch to lock unlimited memory

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,27 @@
 ---
 # handlers file for elk
+
+# The daemon-reload handler must be declared BEFORE the handlers
+# it works in conjunction with. It's unintuitive, but Ansible runs
+# handlers in the order they are declared, not in the order they
+# are called (i.e. in `handlers/main.yml`, this file). See:
+# http://docs.ansible.com/ansible/glossary.html#notify
+- name: reload systemd
+  command: /bin/systemctl daemon-reload
+
+- name: restart ufw
+  service:
+    name: ufw
+    state: restarted
+
 - name: restart nginx
   service:
     name: nginx
+    state: restarted
+
+- name: restart elasticsearch
+  service:
+    name: elasticsearch
     state: restarted
 
 - name: restart logstash
@@ -13,17 +32,4 @@
 - name: restart kibana
   service:
     name: kibana
-    state: restarted
-
-- name: restart elasticsearch
-  service:
-    name: elasticsearch
-    state: restarted
-
-- name: reload systemd
-  command: /bin/systemctl daemon-reload
-
-- name: restart ufw
-  service:
-    name: ufw
     state: restarted

--- a/spec/elasticsearch_spec.rb
+++ b/spec/elasticsearch_spec.rb
@@ -30,6 +30,14 @@ describe file('/etc/elasticsearch/elasticsearch.yml') do
   its('content') { should match(/^bootstrap\.mlockall: true/) }
 end
 
+describe file('/usr/lib/systemd/system/elasticsearch.service') do
+  it { should be_file }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should eq '644' }
+  its('content') { should match(/^LimitMEMLOCK=infinity$/) }
+end
+
 # Expect the heap size to be half the available RAM in MB.
 #
 available_memory = host_inventory['memory']['total']

--- a/spec/elasticsearch_spec.rb
+++ b/spec/elasticsearch_spec.rb
@@ -40,6 +40,7 @@ describe file('/etc/default/elasticsearch') do
   its('group') { should eq 'root' }
   its('mode') { should eq '644' }
   its('content') { should match(/^ES_HEAP_SIZE=#{desired_heap_size}m/) }
+  its('content') { should match(/^MAX_LOCKED_MEMORY=unlimited$/) }
 end
 
 describe file('/etc/security/limits.conf') do

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -68,9 +68,15 @@
 - name: Configure ElasticSearch heap size.
   lineinfile:
     dest: /etc/default/elasticsearch
-    regexp: "^ES_HEAP_SIZE"
-    line: "ES_HEAP_SIZE={{ elasticsearch_heap_size }}m"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
     state: present
+  with_items:
+    - regexp: "^ES_HEAP_SIZE"
+      line: "ES_HEAP_SIZE={{ elasticsearch_heap_size }}m"
+    - regexp: "^MAX_LOCKED_MEMORY"
+      line: "MAX_LOCKED_MEMORY=unlimited"
+  notify: restart elasticsearch
 
 - name: Set PAM limits for elasticsearch user.
   pam_limits:

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -78,6 +78,16 @@
       line: "MAX_LOCKED_MEMORY=unlimited"
   notify: restart elasticsearch
 
+- name: Raises memlock limits for elasticsearch in systemd config.
+  lineinfile:
+    dest: /usr/lib/systemd/system/elasticsearch.service
+    regexp: "^#?LimitMEMLOCK="
+    line: "LimitMEMLOCK=infinity"
+    state: present
+  notify:
+    - reload systemd
+    - restart elasticsearch
+
 - name: Set PAM limits for elasticsearch user.
   pam_limits:
     domain: "{{ item.domain }}"


### PR DESCRIPTION
Builds on the approach started in #10 and #31 to permit the elasticsearch service to lock memory greedily. Simply setting the `mlockall: true` in the elasticsearch YAML config is not sufficient; this PR updates systemd init files and default env vars as well.

The handlers file has been reordered. Take a look at 4a8d0b7 to understand why—briefly, Ansible runs handlers in the order they are declared, not in the order they are notified. Therefore the reorder is necessary to ensure that the daemon-reload handler runs first, prior to any service restarts.

Closes #42.