### PR TITLE
Supports dry run mode via --check playbook flag

### DIFF
--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -25,6 +25,7 @@
 - name: Gather list of existing Logstash plugins.
   command: /opt/logstash/bin/plugin list
   changed_when: false
+  always_run: true
   register: logstash_plugin_check_result
 
 - name: Install Logstash plugins.


### PR DESCRIPTION
The read-only task for registering a list of installed logstash plugins
must run in order for the subsequent task that inspects the list results
to complete. This single, one-line change enables the entire role to be
run with the --check option (assuming it's already been applied once).