### PR TITLE
Fix check for default permissions for /opt/kibana to root:root 775

### DIFF
--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -23,7 +23,7 @@ describe file('/opt/kibana') do
   it { should be_directory }
   its('owner') { should eq 'root' }
   its('group') { should eq 'root' }
-  its('mode') { should eq '755' }
+  its('mode') { should eq '775' }
 
   # Intentionally redundant test for backwards compatibility. Prior versions
   # of the role set /opt/kibana to a symlink for tarball extraction.


### PR DESCRIPTION
The role created from scratch did not pass `molecule test`.

The default permissions for `/opt/kibana` are set to 775 and the Serverspec check was expecting 755:

```
vagrant@logserver:~$ ls -ld /opt/kibana
drwxrwxr-x 10 root root 4096 Aug  6 05:25 /opt/kibana
vagrant@logserver:~$
```