### PR TITLE
Bumps Kibana version 4.5 -> 4.6

### DIFF
--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require 'spec_helper'
 
-kibana_version = '4.5'
+kibana_version = '4.6'
 
 describe file('/etc/apt/sources.list.d/'\
               'packages_elastic_co_kibana_4_5_debian.list') do

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Kibana apt repo.
   apt_repository:
-    repo: "deb http://packages.elastic.co/kibana/4.5/debian stable main"
+    repo: "deb http://packages.elastic.co/kibana/4.6/debian stable main"
     state: present
   notify:
     - reload systemd


### PR DESCRIPTION
Why not? https://www.elastic.co/guide/en/kibana/current/releasenotes.html
