### PR TITLE
Selective silencing of users for SSH login alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ elk_kibana_default_app: discover
 
 # Some users log in so frequently that you don't want to alert
 # for them. List those here.
-logstash_alert_ssh_silenced_users: []
+elk_logstash_alert_ssh_silenced_users: []
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ elk_kibana_password: kibana
 # dashboard names with hyphens, since Kibana expects it.
 elk_kibana_default_app: discover
 
+# Some users log in so frequently that you don't want to alert
+# for them. List those here.
+logstash_alert_ssh_silenced_users: []
+
 ```
 
 ## Usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,4 +79,4 @@ elk_configure_firewall: true
 
 # Some users log in so frequently that you don't want to alert
 # for them. List those here.
-logstash_alert_ssh_silenced_users: []
+elk_logstash_alert_ssh_silenced_users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,3 +76,7 @@ elk_kibana_default_app: discover
 # Enable automatic configuration of IP whitelisting for "logclients".
 # Uses ufw. Disable if you're using a different role for firewall config.
 elk_configure_firewall: true
+
+# Some users log in so frequently that you don't want to alert
+# for them. List those here.
+logstash_alert_ssh_silenced_users: []

--- a/files/logstash-configs/21-ssh-logins.conf
+++ b/files/logstash-configs/21-ssh-logins.conf
@@ -49,8 +49,8 @@ filter {
       add_field => { "alert_message" => "Interactive SSH login for user %{username} from IP %{src_ip}" }
       break_on_match => false
     }
-{% if (logstash_alert_ssh_silenced_users is defined) and (logstash_alert_ssh_silenced_users | length > 0) %}
-    if [username] in ["{{ logstash_alert_ssh_silenced_users | join('", "') }}"] {
+{% if (elk_logstash_alert_ssh_silenced_users is defined) and (elk_logstash_alert_ssh_silenced_users | length > 0) %}
+    if [username] in ["{{ elk_logstash_alert_ssh_silenced_users | join('", "') }}"] {
       grok {
         remove_tag => [ "slack_alert", "ssh_success" ]
       }

--- a/files/logstash-configs/21-ssh-logins.conf
+++ b/files/logstash-configs/21-ssh-logins.conf
@@ -49,7 +49,13 @@ filter {
       add_field => { "alert_message" => "Interactive SSH login for user %{username} from IP %{src_ip}" }
       break_on_match => false
     }
-  }
+{% if (logstash_alert_ssh_silenced_users is defined) and (logstash_alert_ssh_silenced_users | length > 0) %}
+    if [username] in ["{{ logstash_alert_ssh_silenced_users | join('", "') }}"] {
+      grok {
+        remove_tag => [ "slack_alert", "ssh_success" ]
+      }
+    }
+{% endif %}
   if "ssh" in [tags] {
     date {
       match => ["timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss"]


### PR DESCRIPTION
Users in the `logstash_alert_ssh_silenced_users` list will not trigger Riemann events / Slack alerts upon successful SSH authentication.
