### PR TITLE
Updates with_items syntax with explicit variable interpolation

### DIFF
--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -26,7 +26,7 @@
 - name: Install Logstash plugins.
   command: /opt/logstash/bin/plugin install {{ item }}
   when: item not in logstash_plugin_check_result.stdout
-  with_items: elk_logstash_plugins
+  with_items: "{{ elk_logstash_plugins }}"
 
 - name: Create Logstash config directories.
   file:

--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -31,7 +31,7 @@
     from_ip: "{{ hostvars[item]['ansible_'+elk_network_interface].ipv4.address }}"
     port: 5000
   notify: restart ufw
-  with_items: groups.logclients
+  with_items: "{{ groups.logclients }}"
   # Using conditional to avoid undefined failure if facts haven't been gathered from logclients.
   # Ansible v2 interprets args to `with_items` dynamically, which introduces the error.
   # Make sure to include a gather_facts play on all logclients prior to running this role.


### PR DESCRIPTION
The old-style non-handlebars syntax has been deprecated since v2, and
breaks as of Ansible v2.2. Updating the with_items lines fixes.