### PR TITLE
Various version updates for the stack

### DIFF
--- a/spec/elasticsearch_spec.rb
+++ b/spec/elasticsearch_spec.rb
@@ -14,7 +14,7 @@ end
 describe package('elasticsearch') do
   it { should be_installed }
   # Might be a little aggressive to test for exact version number.
-  its('version') { should >= '2.2.0' }
+  its('version') { should >= '2.4.2' }
 end
 describe package('openjdk-7-jre-headless') do
   it { should be_installed }

--- a/spec/kibana_spec.rb
+++ b/spec/kibana_spec.rb
@@ -4,12 +4,12 @@ require 'spec_helper'
 kibana_version = '4.6'
 
 describe file('/etc/apt/sources.list.d/'\
-              'packages_elastic_co_kibana_4_5_debian.list') do
+              'packages_elastic_co_kibana_4_6_debian.list') do
   it { should be_file }
   its('mode') { should eq '420' }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
-  repo_url = 'http://packages.elastic.co/kibana/4.5/debian'
+  repo_url = 'http://packages.elastic.co/kibana/4.6/debian'
   its('content') { should include "deb #{repo_url}" }
 end
 

--- a/spec/logstash_spec.rb
+++ b/spec/logstash_spec.rb
@@ -2,12 +2,12 @@
 require 'spec_helper'
 
 describe file('/etc/apt/sources.list.d/'\
-              'packages_elastic_co_logstash_2_2_debian.list') do
+              'packages_elastic_co_logstash_2_3_debian.list') do
   it { should be_file }
   its('mode') { should eq '420' }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
-  repo_url = 'http://packages.elastic.co/logstash/2.2/debian'
+  repo_url = 'http://packages.elastic.co/logstash/2.3/debian'
   its('content') { should include "deb #{repo_url}" }
 end
 
@@ -15,7 +15,7 @@ describe package('logstash') do
   it { should be_installed }
   # Might be a little aggressive to test for exact version number.
   # Seeing an oddly formatted version number; ElasticSearch is simply '2.1.1'.
-  its('version') { should >= '1:2.1.2-1' }
+  its('version') { should >= '1:2.3.4-1' }
 end
 
 describe file('/etc/logstash/conf.d') do

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Logstash apt repo.
   apt_repository:
-    repo: "deb http://packages.elastic.co/logstash/2.2/debian stable main"
+    repo: "deb http://packages.elastic.co/logstash/2.3/debian stable main"
     state: present
 
 - name: Install Logstash.


### PR DESCRIPTION
Updates Logstash to 2.3.x, also updates spec to reflect current Kibana and ElasticSearch versions.

I went through the Kibana/ES/Logstash 5.0 update and it's quite messy and destructive, would require massive changes to this role. These are the safest version bumps you can get while maintaining existing compatibility.