### PR TITLE
Allow override of nginx task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,6 @@ elk_kibana_default_app: discover
 # Uses ufw. Disable if you're using a different role for firewall config.
 elk_configure_firewall: true
 
-# Allow downstream playbooks to utilize internal webserver configuration
-# Set this to true in order to skip over this role's nginx rollout
-elk_custom_nginx_config: false
+# Allow downstream playbooks to utilize custom webserver configuration
+# Set this to false in order to skip over this role's nginx rollout
+elk_configure_nginx: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,3 +76,7 @@ elk_kibana_default_app: discover
 # Enable automatic configuration of IP whitelisting for "logclients".
 # Uses ufw. Disable if you're using a different role for firewall config.
 elk_configure_firewall: true
+
+# Allow downstream playbooks to utilize internal webserver configuration
+# Set this to true in order to skip over this role's nginx rollout
+elk_custom_nginx_config: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
   tags: kibana
 
 - include: nginx.yml
+  when: elk_custom_nginx_config == false
   tags: nginx
 
 - include: ufw.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   tags: kibana
 
 - include: nginx.yml
-  when: elk_custom_nginx_config == false
+  when: elk_configure_nginx == true
   tags: nginx
 
 - include: ufw.yml


### PR DESCRIPTION
This is necessary if upstream playbooks using this role are using different web server config and don't want this to clobber local changes.