### PR TITLE
Adds Nginx log parsing logic

### DIFF
--- a/files/logstash-configs/13-nginx.conf
+++ b/files/logstash-configs/13-nginx.conf
@@ -1,0 +1,20 @@
+filter {
+  if [type] == "nginx" {
+    grok {
+      patterns_dir   => "/etc/logstash/patterns.d"
+      match => { "message" => ["%{NGINXACCESS}", "%{NGINXERROR}"] }
+    }
+    geoip {
+      source => "clientip"
+      target => "geoip"
+      add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
+      add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
+    }
+    mutate {
+      convert => [ "[geoip][coordinates]", "float"]
+    }
+    date {
+      match => [ "timestamp" , "dd/MMM/yyyy:HH:mm:ss Z" ]
+    }
+  }
+}

--- a/files/logstash-patterns/nginx
+++ b/files/logstash-patterns/nginx
@@ -1,0 +1,7 @@
+# Courtesy of the DigitalOcean guide at https://www.digitalocean.com/community/questions/logstash-nginx-and-httpd-logs
+NGUSERNAME [a-zA-Z\.\@\-\+_%]+
+NGUSER %{NGUSERNAME}
+NGINXACCESS %{IPORHOST:clientip} %{NGUSER:ident} %{NGUSER:auth} \[%{HTTPDATE:timestamp}\] "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:httpversion}" %{NUMBER:response} (?:%{NUMBER:bytes}|-) (?:"(?:%{URI:referrer}|-)"|%{QS:referrer}) %{QS:agent}
+
+# Custom, a bit hacky, but gets the job done.
+NGINXERROR %{DATA:date} %{DATA:time} \[%{WORD:type}\] %{DATA:error_number}: %{DATA:error_message}, client: %{IPORHOST:clientip}, server: %{IPORHOST:server}, request: %{QS:request}, host: "%{IPORHOST:host}"


### PR DESCRIPTION
Uses some community-maintained patterns and a quick-and-dirty `type` of
"nginx" to trigger the parsing. Optimistically assuming that any
nginx-related log files will match one of two formats:

  * `NGINXACCESS` (e.g. `/var/log/nginx/access.log`)
  * `NGINXERROR` (e.g. `/var/log/nginx/error.log`)

Lazily using a single grok declaration to attempt matching against both
patterns. The upside here is simple reuse of the geoip logic; the
downside is that ES won't see discrete `nginx-access` and `nginx-error`
tags.