### PR TITLE
Include elasticsearch-curator in the ELK role

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ elk_logstash_filters:
 
 # Declare fileglob of GeoIP databases to copy. Off by default.
 elk_logstash_geoipdbs: []
+
+# Sets up Curator to automatically delete old Logstash indices and save
+# disk space. Off by default.
+elk_configure_curator: false
+
+# Indexes older than this number of days will be deleted on a weekly basis
+elk_curator_days_to_keep: 90
 ```
 
 ## Usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,3 +89,10 @@ elk_logstash_filters:
 
 # Declare fileglob of GeoIP databases to copy. Off by default.
 elk_logstash_geoipdbs: []
+
+# Sets up Curator to automatically delete old Logstash indices and save
+# disk space. Off by default.
+elk_configure_curator: false
+
+# Indexes older than this number of days will be deleted on a weekly basis
+elk_curator_days_to_keep: 90

--- a/files/curator.yml
+++ b/files/curator.yml
@@ -1,0 +1,25 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+client:
+  hosts:
+    - 127.0.0.1
+  port: 9200
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  aws_key:
+  aws_secret_key:
+  aws_region:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/tasks/curator.yml
+++ b/tasks/curator.yml
@@ -1,0 +1,41 @@
+---
+- name: Add Curator apt repo.
+  apt_repository:
+    repo: "deb http://packages.elastic.co/curator/5/debian stable main"
+    state: present
+
+- name: Install Curator.
+  apt:
+    name: elasticsearch-curator
+    state: latest
+    update_cache: yes
+
+- name: Create Curator configuration directory.
+  file:
+    path: /etc/curator
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Copy Curator configuration.
+  file:
+    src: curator.yml
+    dest: "/etc/curator/curator.yml"
+    mode: "0644"
+    owner: root
+    group: root
+
+- name: Copy Curator script to delete old indices.
+  template:
+    src: delete_indices.yml.j2
+    dest: "/etc/curator/delete_indices.yml"
+    mode: "0644"
+    owner: root
+    group: root
+
+- name: Add cron job to run Curator regularly.
+  cron:
+    name: "delete old elasticsearch indices"
+    job: "curator /etc/curator/delete_indices.yml --config /etc/curator/curator.yml"
+    special_time: "weekly"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,3 +26,7 @@
 - include: snapshot.yml
   when: elk_elasticsearch_snapshot == true
   tags: snapshot
+
+- include: curator.yml
+  when: elk_configure_curator == true
+  tags: curator

--- a/templates/delete_indices.yml.j2
+++ b/templates/delete_indices.yml.j2
@@ -1,0 +1,31 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices older than {{ elk_curator_days_to_keep }} days (based on index name).
+      Ignore the error if the filter does not result in an actionable
+      list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      timeout_override:
+      continue_if_exception: False
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: {{ elk_curator_days_to_keep }}
+      exclude:


### PR DESCRIPTION
Provides for optional installation of Curator and the ability to automatically delete old Logstash indices from ElasticSearch on a regular basis.