### PR TITLE
Include grok pattern for Tor heartbeat data throughput

### DIFF
--- a/files/logstash-configs/25-tor.conf
+++ b/files/logstash-configs/25-tor.conf
@@ -9,6 +9,7 @@ filter {
       remove_tag => "_grokparsefailure"
     }
 
+    # Jan 30 07:09:10.000 [notice] Heartbeat: Tor's uptime is 7:54 hours, with 23787 circuits open. I've sent 162.27 GB and received 159.16 GB.
     grok {
       patterns_dir => [ "/etc/logstash/patterns.d" ]
       match => { "message" => "%{TOR_HEARTBEAT}" }

--- a/files/logstash-configs/25-tor.conf
+++ b/files/logstash-configs/25-tor.conf
@@ -11,6 +11,13 @@ filter {
 
     grok {
       patterns_dir => [ "/etc/logstash/patterns.d" ]
+      match => { "message" => "%{TOR_HEARTBEAT}" }
+      add_tag => "tor_heartbeat"
+      remove_tag => "_grokparsefailure"
+    }
+
+    grok {
+      patterns_dir => [ "/etc/logstash/patterns.d" ]
       match => { "message" => "%{TOR_LOG}" }
       add_tag => "tor"
       remove_tag => "_grokparsefailure"

--- a/files/logstash-patterns/tor
+++ b/files/logstash-patterns/tor
@@ -1,7 +1,7 @@
 TOR_UPTIME %{BASE10NUM} days %{BASE10NUM}:%{BASE10NUM} hours
 TOR_BANDWIDTH [%{BASE10NUM}.]+\s%{WORD}
 TOR_LOG_PREFIX %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:message_type}\]
-TOR_HEARTBEAT %{TOR_LOG_PREFIX} {HEARTBEAT} Heartbeat: Tor's uptime is %{BASE10NUM:tor_uptime_days} days %{BASE10NUM:tor_uptime_hours}:%{BASE10NUM:tor_uptime_minutes} hours, with %{BASE10NUM:tor_circuits_open} circuits open. I've sent %{BASE16FLOAT:tor_data_sent} %{WORD:tor_data_sent_unit} and received %{BASE16FLOAT:tor_data_received} %{WORD:tor_data_received_unit}.
+TOR_HEARTBEAT %{TOR_LOG_PREFIX} {HEARTBEAT} Heartbeat: Tor's uptime is %{GREEDYDATA:tor_uptime}, with %{BASE10NUM:tor_circuits_open} circuits open. I've sent %{BASE16FLOAT:tor_data_sent} %{WORD:tor_data_sent_unit} and received %{BASE16FLOAT:tor_data_received} %{WORD:tor_data_received_unit}.
 TOR_LOG %{TOR_LOG_PREFIX} %{GREEDYDATA:message}
 TOR_INFO_LOG %{TOR_LOG_PREFIX} %{WORD:action}(_*\(\))?: %{GREEDYDATA:message}
 TOR_NOTICE_TYPE [\w\s]+

--- a/files/logstash-patterns/tor
+++ b/files/logstash-patterns/tor
@@ -1,7 +1,7 @@
 TOR_UPTIME %{BASE10NUM} days %{BASE10NUM}:%{BASE10NUM} hours
 TOR_BANDWIDTH [%{BASE10NUM}.]+\s%{WORD}
 TOR_LOG_PREFIX %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:message_type}\]
-TOR_HEARTBEAT %{TOR_LOG_PREFIX} {HEARTBEAT} Heartbeat: Tor's uptime is %{GREEDYDATA:tor_uptime}, with %{BASE10NUM:tor_circuits_open} circuits open. I've sent %{BASE16FLOAT:tor_data_sent} %{WORD:tor_data_sent_unit} and received %{BASE16FLOAT:tor_data_received} %{WORD:tor_data_received_unit}.
+TOR_HEARTBEAT %{TOR_LOG_PREFIX} (%{SPACE}%{DATA:tor_log_message_domain})? Heartbeat: Tor's uptime is (%{BASE10NUM:tor_uptime_days} (day|days)%{SPACE})?%{HOUR:tor_uptime_hours}:%{MINUTE:tor_uptime_minutes} hours, with %{BASE10NUM:tor_circuits_open} circuits open. I've sent %{BASE16FLOAT:tor_data_sent} %{WORD:tor_data_sent_unit} and received %{BASE16FLOAT:tor_data_received} %{WORD:tor_data_received_unit}.
 TOR_LOG %{TOR_LOG_PREFIX} %{GREEDYDATA:message}
 TOR_INFO_LOG %{TOR_LOG_PREFIX} %{WORD:action}(_*\(\))?: %{GREEDYDATA:message}
 TOR_NOTICE_TYPE [\w\s]+

--- a/files/logstash-patterns/tor
+++ b/files/logstash-patterns/tor
@@ -1,6 +1,7 @@
 TOR_UPTIME %{BASE10NUM} days %{BASE10NUM}:%{BASE10NUM} hours
 TOR_BANDWIDTH [%{BASE10NUM}.]+\s%{WORD}
 TOR_LOG_PREFIX %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:message_type}\]
+TOR_HEARTBEAT %{TOR_LOG_PREFIX} {HEARTBEAT} Heartbeat: Tor's uptime is %{BASE10NUM:tor_uptime_days} days %{BASE10NUM:tor_uptime_hours}:%{BASE10NUM:tor_uptime_minutes} hours, with %{BASE10NUM:tor_circuits_open} circuits open. I've sent %{BASE16FLOAT:tor_data_sent} %{WORD:tor_data_sent_unit} and received %{BASE16FLOAT:tor_data_received} %{WORD:tor_data_received_unit}.
 TOR_LOG %{TOR_LOG_PREFIX} %{GREEDYDATA:message}
 TOR_INFO_LOG %{TOR_LOG_PREFIX} %{WORD:action}(_*\(\))?: %{GREEDYDATA:message}
 TOR_NOTICE_TYPE [\w\s]+


### PR DESCRIPTION
Very useful data to have; especially if you're operating a relay (exit/middle) or bridge. This pattern parses the heartbeat in the log (which I believe is printed once per hour) which tells you how many bytes have passed through your Tor daemon. 

I've learned that it helps Kibana's visualization capability to explicitly declare types in the grok pattern (e.g. %{BASE10NUM:variable_name:int}), (otherwise the fields are unanalyzed?) but not doing that here. 